### PR TITLE
Refactor/queue/#42 layer separation and refactoring

### DIFF
--- a/queue-service/src/main/java/com/bidulgi/queueservice/application/QueueService.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/application/QueueService.java
@@ -1,7 +1,6 @@
 package com.bidulgi.queueservice.application;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -9,6 +8,7 @@ import org.springframework.stereotype.Service;
 import com.bidulgi.queueservice.application.dto.PositionResult;
 import com.bidulgi.queueservice.application.dto.QueueResult;
 import com.bidulgi.queueservice.application.port.TokenGenerator;
+import com.bidulgi.queueservice.domain.vo.DequeueResult;
 import com.bidulgi.queueservice.domain.vo.QueueState;
 import com.bidulgi.queueservice.domain.repository.QueueRepository;
 import com.bidulgi.queueservice.domain.repository.TokenRepository;
@@ -60,24 +60,13 @@ public class QueueService {
 	 */
 	public Mono<QueueResult> dequeue(UUID userId, UUID productId) {
 		return queueRepository.dequeue(userId, productId)
-			.flatMap(result -> {
-				List<String> results = parseDequeueResult(result);
-				UUID nextProductId = UUID.fromString(results.get(0));
-				UUID nextUserId = UUID.fromString(results.get(1));
-
-				return tokenGenerator.createAccessToken(nextUserId, nextProductId) // 토큰 발급 후 저장 및 결과 반환
-					.flatMap(token -> tokenRepository.saveToken(nextUserId, nextProductId, token)
-						.thenReturn(QueueResult.of(nextUserId, nextProductId, QueueState.ACTIVE, token)));
-			});
+			.flatMap(this::processNextUser);
 	}
 
-	// "productId:userId" 형식의 결과를 파싱하여 리스트로 반환
-	private List<String> parseDequeueResult(String result) {
-		String[] parts = result.split(":");
-		if (parts.length != 2) {
-			throw new IllegalArgumentException("Invalid dequeue result format" + result);
-		}
-		return List.of(parts[0], parts[1]);
+	private Mono<QueueResult> processNextUser(DequeueResult nextUser) {
+		return tokenGenerator.createAccessToken(nextUser.userId(), nextUser.productId()) // 토큰 발급 후 저장 및 결과 반환
+			.flatMap(token -> tokenRepository.saveToken(nextUser.userId(), nextUser.productId(), token)
+				.thenReturn(QueueResult.of(nextUser.userId(), nextUser.productId(), QueueState.ACTIVE, token)));
 	}
 
 	/**

--- a/queue-service/src/main/java/com/bidulgi/queueservice/application/event/ReservationCompletedEventHandler.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/application/event/ReservationCompletedEventHandler.java
@@ -1,0 +1,33 @@
+package com.bidulgi.queueservice.application.event;
+
+import java.util.UUID;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.bidulgi.queueservice.application.QueueService;
+import com.bidulgi.queueservice.domain.event.ReservationCompletedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationCompletedEventHandler {
+
+	private final QueueService queueService;
+
+	@EventListener
+	public void handleReservationCompletedEvent(ReservationCompletedEvent event) {
+		queueService.dequeue(event.userId(), event.productId())
+			.doOnNext(result -> log.info("대기열 dequeue 완료. 다음 사용자 활성화: userId={}, productId={}, state={}",
+				result.userId(), result.productId(), result.state()))
+			.switchIfEmpty(Mono.fromRunnable(() ->
+				log.info("대기열에 활성화할 다음 사용자가 없습니다. productId={}", event.productId())))
+			.doOnError(error -> log.error("예약 완료 이벤트 처리 실패: {}", error.getMessage(), error))
+			.onErrorComplete()
+			.subscribe();
+	}
+}

--- a/queue-service/src/main/java/com/bidulgi/queueservice/application/event/TokenExpiredEventHandler.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/application/event/TokenExpiredEventHandler.java
@@ -21,8 +21,8 @@ public class TokenExpiredEventHandler {
 
 	@EventListener
 	public void handleTokenExpiredEvent(TokenExpiredEvent event) {
-		UUID userId = UUID.fromString(event.userId());
-		UUID productId = UUID.fromString(event.productId());
+		UUID userId = event.userId();
+		UUID productId = event.productId();
 
 		log.info("토큰 만료 이벤트 처리: userId={}, productId={}", userId, productId);
 

--- a/queue-service/src/main/java/com/bidulgi/queueservice/domain/event/ReservationCompletedEvent.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/domain/event/ReservationCompletedEvent.java
@@ -1,0 +1,15 @@
+package com.bidulgi.queueservice.domain.event;
+
+import java.util.UUID;
+
+public record ReservationCompletedEvent(
+	UUID userId,
+	UUID productId
+) {
+	public static ReservationCompletedEvent of(UUID userId, UUID productId) {
+		return new ReservationCompletedEvent(
+			userId,
+			productId
+		);
+	}
+}

--- a/queue-service/src/main/java/com/bidulgi/queueservice/domain/event/TokenExpiredEvent.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/domain/event/TokenExpiredEvent.java
@@ -1,6 +1,15 @@
 package com.bidulgi.queueservice.domain.event;
 
+import java.util.UUID;
+
 public record TokenExpiredEvent(
-	String userId,
-	String productId
-) {}
+	UUID userId,
+	UUID productId
+) {
+	public static TokenExpiredEvent of(String userId, String productId) {
+		return new TokenExpiredEvent(
+			UUID.fromString(userId),
+			UUID.fromString(productId)
+		);
+	}
+}

--- a/queue-service/src/main/java/com/bidulgi/queueservice/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/domain/repository/QueueRepository.java
@@ -3,6 +3,7 @@ package com.bidulgi.queueservice.domain.repository;
 import java.util.UUID;
 
 import com.bidulgi.queueservice.domain.vo.QueueState;
+import com.bidulgi.queueservice.domain.vo.DequeueResult;
 
 import reactor.core.publisher.Mono;
 
@@ -22,7 +23,7 @@ public interface QueueRepository {
 	 * @param productId 상품 아이디
 	 * @return 다음 사용자의 유저 아이디와 상품 아이디
 	 */
-	Mono<String> dequeue(UUID userId, UUID productId);
+	Mono<DequeueResult> dequeue(UUID userId, UUID productId);
 
 	/**
 	 * 대기열 순번 조회

--- a/queue-service/src/main/java/com/bidulgi/queueservice/domain/vo/DequeueResult.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/domain/vo/DequeueResult.java
@@ -1,0 +1,9 @@
+package com.bidulgi.queueservice.domain.vo;
+
+import java.util.UUID;
+
+public record DequeueResult(
+	UUID userId,
+	UUID productId
+) {
+}

--- a/queue-service/src/main/java/com/bidulgi/queueservice/infrastructure/event/ReservationEventListener.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/infrastructure/event/ReservationEventListener.java
@@ -1,19 +1,17 @@
 package com.bidulgi.queueservice.infrastructure.event;
 
-import java.util.UUID;
-
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
-import com.bidulgi.queueservice.application.QueueService;
+import com.bidulgi.queueservice.domain.event.ReservationCompletedEvent;
 import com.bidulgi.queueservice.infrastructure.event.payload.ReservationCompletePayload;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
@@ -23,7 +21,7 @@ public class ReservationEventListener {
 	private static final String EVENT_TYPE_RESERVATION_COMPLETE = "reservationComplete";
 
 	private final ObjectMapper objectMapper;
-	private final QueueService queueService;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@KafkaListener(topics = "reservation", groupId = "queue-service")
 	public void onReservationEvent(
@@ -35,17 +33,9 @@ public class ReservationEventListener {
 		}
 
 		ReservationCompletePayload eventPayload = parsePayload(payload);
-
 		log.info("예약 완료 이벤트 수신: userId={}, productId={}", eventPayload.userId(), eventPayload.productId());
 
-		queueService.dequeue(eventPayload.userId(), eventPayload.productId())
-			.doOnNext(result -> log.info("대기열 dequeue 완료. 다음 사용자 활성화: userId={}, productId={}, state={}",
-				result.userId(), result.productId(), result.state()))
-			.switchIfEmpty(Mono.fromRunnable(() ->
-				log.info("대기열에 활성화할 다음 사용자가 없습니다. productId={}", eventPayload.productId())))
-			.doOnError(error -> log.error("예약 완료 이벤트 처리 실패: {}", error.getMessage(), error))
-			.onErrorComplete()
-			.subscribe();
+		eventPublisher.publishEvent(ReservationCompletedEvent.of(eventPayload.userId(), eventPayload.productId()));
 	}
 
 	private ReservationCompletePayload parsePayload(String payload) {

--- a/queue-service/src/main/java/com/bidulgi/queueservice/infrastructure/event/TokenExpirationEventListener.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/infrastructure/event/TokenExpirationEventListener.java
@@ -37,13 +37,12 @@ public class TokenExpirationEventListener extends KeyExpirationEventMessageListe
 		// 토큰 만료 이벤트 발행
 		TokenKeyInfo keyInfo = parseTokenKey(expiredKey);
 		log.info("토큰 만료 감지: userId={}, productId={}", keyInfo.userId(), keyInfo.productId());
-		eventPublisher.publishEvent(new TokenExpiredEvent(keyInfo.userId(), keyInfo.productId()));
+		eventPublisher.publishEvent(TokenExpiredEvent.of(keyInfo.userId(), keyInfo.productId()));
 	}
 
     private TokenKeyInfo parseTokenKey(String expiredKey) {
         String[] parts = expiredKey.substring(TOKEN_KEY_PREFIX.length()).split(":");
         if (parts.length != 2) {
-			// TODO 커스텀 예외 처리
             throw new IllegalArgumentException("Invalid token key format: " + expiredKey);
         }
         return new TokenKeyInfo(parts[0], parts[1]);

--- a/queue-service/src/main/java/com/bidulgi/queueservice/infrastructure/redis/LuaScriptProvider.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/infrastructure/redis/LuaScriptProvider.java
@@ -101,7 +101,8 @@ public class LuaScriptProvider {
 			
 			        local value = productId .. ":" .. userId
 			        redis.call('SADD', activeKey, value)
-			        return value
+			        local json = string.format('{"productId":"%s","userId":"%s"}', productId, userId)
+			        return json
 			    end
 			end
 			

--- a/queue-service/src/main/java/com/bidulgi/queueservice/infrastructure/repository/QueueRepositoryAdapter.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/infrastructure/repository/QueueRepositoryAdapter.java
@@ -7,11 +7,12 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.StringUtils;
 
+import com.bidulgi.queueservice.domain.vo.DequeueResult;
 import com.bidulgi.queueservice.domain.vo.QueueState;
 import com.bidulgi.queueservice.domain.repository.QueueRepository;
 import com.bidulgi.queueservice.infrastructure.redis.LuaScriptProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -22,6 +23,7 @@ public class QueueRepositoryAdapter implements QueueRepository {
 
 	private final ReactiveRedisTemplate<String, String> redisTemplate;
 	private final LuaScriptProvider luaScriptProvider;
+	private final ObjectMapper objectMapper;
 
 	private static final String ACTIVE_KEY = "queue:active";
 	private static final String WAITING_PRODUCTS_KEY = "queue:waiting:products";
@@ -43,14 +45,14 @@ public class QueueRepositoryAdapter implements QueueRepository {
 	}
 
 	@Override
-	public Mono<String> dequeue(UUID userId, UUID productId) {
+	public Mono<DequeueResult> dequeue(UUID userId, UUID productId) {
 		String valueToRemove = productId + ":" + userId;
 		return redisTemplate.execute(
 			luaScriptProvider.getDequeueScript(),
 			List.of(ACTIVE_KEY, WAITING_PRODUCTS_KEY),
 			valueToRemove
 		).singleOrEmpty()
-			.filter(StringUtils::hasText);
+			.flatMap(this::parseDequeueResult);
 	}
 
 	@Override
@@ -72,4 +74,18 @@ public class QueueRepositoryAdapter implements QueueRepository {
 	private String generateWaitingKey(UUID productId) {
 		return "queue:waiting:" + productId;
 	}
+
+	private Mono<DequeueResult> parseDequeueResult(String jsonResult) {
+		try {
+			DequeueResultPayload payload = objectMapper.readValue(jsonResult, DequeueResultPayload.class);
+			return Mono.just(new DequeueResult(
+				UUID.fromString(payload.userId()),
+				UUID.fromString(payload.productId())
+			));
+		} catch (Exception e) {
+			return Mono.error(new IllegalArgumentException("Invalid dequeue result format: " + jsonResult, e));
+		}
+	}
+
+	private record DequeueResultPayload(String userId, String productId) {}
 }

--- a/queue-service/src/main/java/com/bidulgi/queueservice/presentation/GlobalExceptionHandler.java
+++ b/queue-service/src/main/java/com/bidulgi/queueservice/presentation/GlobalExceptionHandler.java
@@ -1,0 +1,110 @@
+package com.bidulgi.queueservice.presentation;
+
+import java.time.format.DateTimeParseException;
+import java.util.NoSuchElementException;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.support.WebExchangeBindException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.MethodNotAllowedException;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebInputException;
+
+import com.bidulgi.common.globalException.ErrorCode;
+import com.bidulgi.common.globalException.ErrorResponse;
+import com.bidulgi.common.globalException.custom.AuthorizationException;
+import com.bidulgi.common.globalException.custom.EntityNotFoundException;
+import com.bidulgi.common.globalException.custom.ExternalServiceException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler({
+		IllegalArgumentException.class,
+		NoSuchElementException.class,
+		DateTimeParseException.class,
+		ServerWebInputException.class
+	})
+	public ResponseEntity<ErrorResponse> handleCommonException(Exception e) {
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_TYPE_VALUE, e.getMessage());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage());
+		return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+	}
+
+	@ExceptionHandler(AuthorizationException.class)
+	public ResponseEntity<ErrorResponse> handleAuthorizationException(AuthorizationException e) {
+		final ErrorResponse response = ErrorResponse.of(e.getErrorCode(), e.getMessage());
+		return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
+	}
+
+	/**
+	 * @Valid 으로 binding error 발생시
+	 */
+	@ExceptionHandler(WebExchangeBindException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(WebExchangeBindException e) {
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * @Validated 으로 binding error 발생시
+	 */
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getMessage());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * @ModelAttribute 으로 binding error 발생시
+	 */
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+		final ErrorResponse response = ErrorResponse.of(e);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * 지원하지 않은 HTTP method로 호출 할 경우
+	 */
+	@ExceptionHandler(MethodNotAllowedException.class)
+	public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(MethodNotAllowedException e) {
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+		return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+	}
+
+	@ExceptionHandler(ResponseStatusException.class)
+	public ResponseEntity<ErrorResponse> handleResponseStatusException(ResponseStatusException e) {
+		if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+			return new ResponseEntity<>(ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND, e.getReason()), HttpStatus.NOT_FOUND);
+		}
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.BAD_REQUEST, e.getReason());
+		return new ResponseEntity<>(response, e.getStatusCode());
+	}
+
+	@ExceptionHandler(ExternalServiceException.class)
+	public ResponseEntity<ErrorResponse> handleExternalServiceException(ExternalServiceException e) {
+		log.error("handleExternalServiceException: {}", e.getMessage());
+		final ErrorResponse response = ErrorResponse.of(e.getErrorCode());
+		return new ResponseEntity<>(response, HttpStatus.BAD_GATEWAY);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception e) {
+		log.error("{}: {}", e.getClass(), e.getMessage());
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #42

## 📝 개요
- 예약 완료 이벤트 계층 의존 위배 → 이벤트 발행으로 계층 분리
- Dequeue 결과를 ObjectMapper를 사용하여 VO 매핑
- WebFlux이므로 Common에 있는 GlobalExceptionHandler 사용 불가 → 따로 추가 

## 🔁 변경 사항
- 변경 사항을 작성해주세요.

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타